### PR TITLE
Add Crew verbosity option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TELEGRAM_BOT_TOKEN=your-telegram-token
 OPENAI_API_KEY=sk-your-key
 OPENAI_API_BASE=https://api.deepseek.com/v1
+CREW_VERBOSE=True

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See `AGENTS.md` for contributor guidelines.
 ```bash
 pip install -r requirements.txt
 ```
-2. Create a `.env` file based on the variables in `.env.example` and provide your tokens.
+2. Create a `.env` file based on the variables in `.env.example` and provide your tokens. `CREW_VERBOSE` controls whether CrewAI prints progress (default `True`).
 3. Run the ingestion script before starting the bot:
 ```bash
 python scripts/ingest_document.py

--- a/adapters/output/faiss_rag.py
+++ b/adapters/output/faiss_rag.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 from typing import List
 
-import faiss
-from langchain.embeddings import OpenAIEmbeddings
-from langchain.vectorstores import FAISS
 from domain.ports.rag_port import RAGPort
 
 

--- a/app/container.py
+++ b/app/container.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from adapters.input.telegram_bot import TelegramBot
@@ -18,6 +19,7 @@ class Container:
         rag = FAISSRAG(index_dir)
         llm = DeepSeekLLM()
         tool = DocumentSearchTool(rag)
+        verbose = os.getenv("CREW_VERBOSE", "True").lower() in ("1", "true", "yes")
 
         analyst = QuestionAnalyst(llm=llm)
         researcher = ContentResearcher(tool=tool)
@@ -27,5 +29,6 @@ class Container:
             analyst=analyst,
             researcher=researcher,
             writer=writer,
+            verbose=verbose,
         )
         self.bot = TelegramBot(qa_handler=self.qa_service.answer)

--- a/domain/services/qa_service.py
+++ b/domain/services/qa_service.py
@@ -8,11 +8,24 @@ from domain.agents.question_analyst import QuestionAnalyst
 
 @dataclass
 class QAService:
-    """Orchestrates the three agents to answer questions."""
+    """Orchestrates the three agents to answer questions.
+
+    Attributes
+    ----------
+    analyst:
+        Agent responsible for analyzing the question.
+    researcher:
+        Agent that searches for relevant snippets.
+    writer:
+        Agent that writes the final answer.
+    verbose:
+        Whether to enable Crew progress output.
+    """
 
     analyst: QuestionAnalyst
     researcher: ContentResearcher
     writer: AnswerWriter
+    verbose: bool = True
 
     def answer(self, question: str) -> str:
         """Execute the crew to produce the final answer."""
@@ -69,7 +82,7 @@ class QAService:
         crew = Crew(
             agents=[analyst_agent, researcher_agent, writer_agent],
             tasks=[analyze, research, write],
-            verbose=False,
+            verbose=self.verbose,
         )
 
         return crew.kickoff(inputs={"question": question})


### PR DESCRIPTION
## Summary
- add a `verbose` attribute to `QAService` and pass it to `Crew`
- make `Container` read `CREW_VERBOSE` and propagate it to `QAService`
- document the new env var
- allow tests to run without the `faiss` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e98672000832886cf43c6fc8d4a32