### PR TITLE
Fix LangChain imports

### DIFF
--- a/adapters/output/faiss_rag.py
+++ b/adapters/output/faiss_rag.py
@@ -14,8 +14,8 @@ class FAISSRAG(RAGPort):
                 f"Index not found at {index_path}. Run ingest_document.py first."
             )
 
-        from langchain.embeddings import OpenAIEmbeddings
-        from langchain.vectorstores import FAISS
+        from langchain_community.embeddings import OpenAIEmbeddings
+        from langchain_community.vectorstores import FAISS
 
         self.index_path = index_path
         self.embeddings = OpenAIEmbeddings()

--- a/domain/agents/question_analyst.py
+++ b/domain/agents/question_analyst.py
@@ -12,7 +12,7 @@ class QuestionAnalyst:
     def analyze(self, question: str) -> str:
         """Return a short description of main topics."""
         prompt = (
-            "Liste de forma resumida os principais tópicos da pergunta a seguir:"\
+            "Liste de forma resumida os principais tópicos da pergunta a seguir:"
             f"\n{question}\nTópicos:"
         )
         return self.llm.complete(prompt)

--- a/scripts/ingest_document.py
+++ b/scripts/ingest_document.py
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 
-from langchain.embeddings import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import FAISS
+from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.vectorstores import FAISS
 from dotenv import load_dotenv
 
 

--- a/tests/test_ingest_document.py
+++ b/tests/test_ingest_document.py
@@ -11,12 +11,16 @@ def test_ingest_document(tmp_path: Path, monkeypatch) -> None:
     faiss_module = ModuleType("faiss")
     faiss_module.FAISS = Mock()
 
-    monkeypatch.setitem(sys.modules, "langchain.embeddings", ModuleType("emb"))
-    sys.modules["langchain.embeddings"].OpenAIEmbeddings = embeddings_cls
+    monkeypatch.setitem(
+        sys.modules, "langchain_community.embeddings", ModuleType("emb")
+    )
+    sys.modules["langchain_community.embeddings"].OpenAIEmbeddings = embeddings_cls
     monkeypatch.setitem(sys.modules, "langchain.text_splitter", ModuleType("split"))
     sys.modules["langchain.text_splitter"].RecursiveCharacterTextSplitter = splitter_cls
-    monkeypatch.setitem(sys.modules, "langchain.vectorstores", ModuleType("vec"))
-    sys.modules["langchain.vectorstores"].FAISS = faiss_module.FAISS
+    monkeypatch.setitem(
+        sys.modules, "langchain_community.vectorstores", ModuleType("vec")
+    )
+    sys.modules["langchain_community.vectorstores"].FAISS = faiss_module.FAISS
     monkeypatch.setitem(sys.modules, "dotenv", ModuleType("dotenv"))
     sys.modules["dotenv"].load_dotenv = Mock()
 


### PR DESCRIPTION
## Summary
- update LangChain import paths in FAISS components
- adjust ingest_document tests for new import paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea2d247488328ba350fbc31c6214a