### PR TITLE
Improve ingestion error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ See `AGENTS.md` for contributor guidelines.
 ```bash
 pip install -r requirements.txt
 ```
-2. Create a `.env` file based on the variables in `.env.example` and provide your tokens. `CREW_VERBOSE` controls whether CrewAI prints progress (default `True`).
-3. Run the ingestion script before starting the bot:
+2. Create a `.env` file based on `.env.example` and provide your tokens. Set
+   `OPENAI_API_KEY` and `OPENAI_API_BASE` for the DeepSeek API. `CREW_VERBOSE`
+   controls whether CrewAI prints progress (default `True`). If ingestion fails
+   with a 404 error, verify that `OPENAI_API_BASE` matches the provider URL.
+3. Build the index by running the ingestion script:
 ```bash
 python scripts/ingest_document.py
 ```
+   This reads `data/documento.txt` and writes the FAISS index to
+   `vector_store/faiss_index`. Edit `scripts/ingest_document.py` if you
+   want to use different paths.
 4. Start the bot:
 ```bash
 python -m app.main

--- a/adapters/output/faiss_rag.py
+++ b/adapters/output/faiss_rag.py
@@ -14,8 +14,8 @@ class FAISSRAG(RAGPort):
                 f"Index not found at {index_path}. Run ingest_document.py first."
             )
 
-        from langchain.embeddings import OpenAIEmbeddings
-        from langchain.vectorstores import FAISS
+        from langchain_openai import OpenAIEmbeddings
+        from langchain_community.vectorstores import FAISS
 
         self.index_path = index_path
         self.embeddings = OpenAIEmbeddings()

--- a/domain/agents/question_analyst.py
+++ b/domain/agents/question_analyst.py
@@ -12,7 +12,7 @@ class QuestionAnalyst:
     def analyze(self, question: str) -> str:
         """Return a short description of main topics."""
         prompt = (
-            "Liste de forma resumida os principais tópicos da pergunta a seguir:"\
+            "Liste de forma resumida os principais tópicos da pergunta a seguir:"
             f"\n{question}\nTópicos:"
         )
         return self.llm.complete(prompt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 python-telegram-bot
 crewai
 langchain
+langchain-community
+langchain-openai
 faiss-cpu
 python-dotenv
 openai

--- a/scripts/ingest_document.py
+++ b/scripts/ingest_document.py
@@ -1,20 +1,33 @@
-"""Script to ingest the base document into a FAISS index."""
+"""Script to ingest the base document into a FAISS index.
+
+The text is loaded from ``DATA_FILE`` (``data/documento.txt`` by default) and
+the resulting index is stored in ``INDEX_DIR`` (``vector_store/faiss_index``).
+OpenAI credentials are read from the environment. Set ``OPENAI_API_KEY`` and
+``OPENAI_API_BASE`` before running. Run this script once before starting the bot.
+"""
 
 from pathlib import Path
+import os
 
-from langchain.embeddings import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import FAISS
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores import FAISS
 from dotenv import load_dotenv
 
 
 load_dotenv()
+
+REQUIRED_VARS = ("OPENAI_API_KEY", "OPENAI_API_BASE")
 
 DATA_FILE = Path("data/documento.txt")
 INDEX_DIR = Path("vector_store/faiss_index")
 
 
 def main() -> None:
+    for var in REQUIRED_VARS:
+        if not os.environ.get(var):
+            raise EnvironmentError(f"Environment variable {var} is not set")
+
     if not DATA_FILE.exists():
         raise FileNotFoundError(f"Document not found at {DATA_FILE}")
 

--- a/tests/test_ingest_document.py
+++ b/tests/test_ingest_document.py
@@ -11,14 +11,19 @@ def test_ingest_document(tmp_path: Path, monkeypatch) -> None:
     faiss_module = ModuleType("faiss")
     faiss_module.FAISS = Mock()
 
-    monkeypatch.setitem(sys.modules, "langchain.embeddings", ModuleType("emb"))
-    sys.modules["langchain.embeddings"].OpenAIEmbeddings = embeddings_cls
+    monkeypatch.setitem(sys.modules, "langchain_openai", ModuleType("openai"))
+    sys.modules["langchain_openai"].OpenAIEmbeddings = embeddings_cls
     monkeypatch.setitem(sys.modules, "langchain.text_splitter", ModuleType("split"))
     sys.modules["langchain.text_splitter"].RecursiveCharacterTextSplitter = splitter_cls
-    monkeypatch.setitem(sys.modules, "langchain.vectorstores", ModuleType("vec"))
-    sys.modules["langchain.vectorstores"].FAISS = faiss_module.FAISS
+    monkeypatch.setitem(
+        sys.modules, "langchain_community.vectorstores", ModuleType("vec")
+    )
+    sys.modules["langchain_community.vectorstores"].FAISS = faiss_module.FAISS
     monkeypatch.setitem(sys.modules, "dotenv", ModuleType("dotenv"))
     sys.modules["dotenv"].load_dotenv = Mock()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_BASE", "url")
 
     ingest_document = importlib.import_module("scripts.ingest_document")
 


### PR DESCRIPTION
## Summary
- explain 404 setup issue in README
- clarify required env vars in `ingest_document.py`
- abort ingestion when variables are missing
- update tests for new checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea2d247488328ba350fbc31c6214a