### PR TITLE
Fix Pydantic attribute name

### DIFF
--- a/tools/document_search_tool.py
+++ b/tools/document_search_tool.py
@@ -20,15 +20,15 @@ class DocumentSearchTool(BaseTool):
 
     name: str = "document_search"
     description: str = "Busca trechos relevantes em um documento."
-    rag: RAGPort = PrivateAttr()
+    _rag: RAGPort = PrivateAttr()
 
     def __init__(self, rag: RAGPort) -> None:
         super().__init__()
-        self.rag = rag
+        self._rag = rag
 
     def run(self, query: str) -> List[str]:
         """Return snippets matching the query."""
-        return self.rag.query(query)
+        return self._rag.query(query)
 
     def _run(self, query: str) -> str:  # pragma: no cover - crewai usage
         return "\n".join(self.run(query))


### PR DESCRIPTION
## Summary
- fix DocumentSearchTool to use sunder name for PrivateAttr

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686141c48ea483289c5d12181df19e88